### PR TITLE
Fix All Colors are UnPacked as SharedColors now

### DIFF
--- a/UMAProject/Assets/UMA/Example/Scripts/UMAPackedRecipeBase.cs
+++ b/UMAProject/Assets/UMA/Example/Scripts/UMAPackedRecipeBase.cs
@@ -620,7 +620,11 @@ public abstract class UMAPackedRecipeBase : UMARecipeBase
 			colorData = new OverlayColorData[0];
 		}
 
-		umaRecipe.sharedColors = colorData;
+		umaRecipe.sharedColors = new OverlayColorData[umaPackRecipe.sharedColorCount];
+       		for (int i = 0; i < umaRecipe.sharedColors.Length; i++)
+	       	{
+	        	umaRecipe.sharedColors[i] = colorData[i];
+	       	}
 
 		for (int i = 0; i < umaPackRecipe.slotsV2.Length; i++)
 		{


### PR DESCRIPTION
Without using the sharedColorCount all colors are being unpacked as SharedColors- this isn't right as some colors are not shared. The previous version did this right, so adding that code back in @623