### PR TITLE
Adding the slot asset name in parenthesis next to the slot name in th…

### DIFF
--- a/UMAProject/Assets/Standard Assets/Editor/UMA/Core/CharacterBaseEditor.cs
+++ b/UMAProject/Assets/Standard Assets/Editor/UMA/Core/CharacterBaseEditor.cs
@@ -716,7 +716,7 @@ namespace UMAEditor
 		public bool OnGUI(ref bool _dnaDirty, ref bool _textureDirty, ref bool _meshDirty)
 		{
 			bool delete;
-			GUIHelper.FoldoutBar(ref _foldout, _name, out delete);
+			GUIHelper.FoldoutBar(ref _foldout, _name + "      (" + _slotData.asset.name + ")", out delete);
 
 			if (!_foldout)
 				return false;


### PR DESCRIPTION
…e foldout.  This helps avoid confusion when working with multiple recipes with different slots, yet the slots are named the same.