### PR TITLE
Allowing the user to drop a folder onto the “Drag Races compatible wi…

### DIFF
--- a/UMAProject/Assets/Standard Assets/Editor/DynamicCharacterSystem/pTextRecipeEditor.cs
+++ b/UMAProject/Assets/Standard Assets/Editor/DynamicCharacterSystem/pTextRecipeEditor.cs
@@ -49,14 +49,42 @@ namespace UMAEditor
 							RaceData tempRaceDataAsset = draggedObjects[i] as RaceData;
 							if (tempRaceDataAsset)
 							{
-                                if(!newcrf.Contains(tempRaceDataAsset.raceName))
-								newcrf.Add(tempRaceDataAsset.raceName);
+								AddRaceDataAsset (tempRaceDataAsset, newcrf);
 								continue;
+							}
+
+							var path = AssetDatabase.GetAssetPath (draggedObjects [i]);
+							if (System.IO.Directory.Exists (path)) 
+							{
+								RecursiveScanFoldersForAssets (path, newcrf);
 							}
 						}
 					}
 				}
 			}
+		}
+
+		private void RecursiveScanFoldersForAssets(string path, List<string> newcrf)
+		{
+			var assetFiles = System.IO.Directory.GetFiles (path, "*.asset");
+			foreach (var assetFile in assetFiles) 
+			{
+				var tempRaceDataAsset = AssetDatabase.LoadAssetAtPath (assetFile, typeof(RaceData)) as RaceData;
+				if (tempRaceDataAsset) 
+				{
+					AddRaceDataAsset (tempRaceDataAsset, newcrf);
+				}
+			}
+			foreach (var subFolder in System.IO.Directory.GetDirectories(path)) 
+			{
+				RecursiveScanFoldersForAssets (subFolder.Replace ('\\', '/'), newcrf);
+			}
+		}
+
+		private void AddRaceDataAsset(RaceData raceDataAsset, List<string> newcrf)
+		{
+			if(!newcrf.Contains(raceDataAsset.raceName))
+				newcrf.Add (raceDataAsset.raceName);
 		}
 
 		List<string> generatedWardrobeSlotOptions = new List<string> ();

--- a/UMAProject/Assets/UMA/Extensions/DynamicCharacterSystem/Scripts/pUMATextRecipe.cs
+++ b/UMAProject/Assets/UMA/Extensions/DynamicCharacterSystem/Scripts/pUMATextRecipe.cs
@@ -310,7 +310,7 @@ public partial class UMATextRecipe : UMAPackedRecipeBase
 			{
 				if (_sharedColors == null)
 				{
-					if (characterColors.Count > 0)
+					if (characterColors != null && characterColors.Count > 0)
 					{
 						var colorData = new OverlayColorData[characterColors.Count];
 						for (int i = 0; i < colorData.Length; i++)


### PR DESCRIPTION
…th this slot here” for wardrobe items.  It will then do a recursive folder search for all RaceData elements and add them to the list of compatible races for that particular asset.

The only drawback of this is the error `ArgumentException: Getting control 8's position in a group with only 8 controls when doing DragPerform` due to the list changing in the middle of an OnInspectorGUI() call.  However, I have noticed no negative side effects to this.