### PR TITLE
overlay and slot library elementlists set to public

### DIFF
--- a/UMAProject/Assets/UMA/Core/Scripts/OverlayLibrary.cs
+++ b/UMAProject/Assets/UMA/Core/Scripts/OverlayLibrary.cs
@@ -5,7 +5,8 @@ using System;
 
 public class OverlayLibrary : OverlayLibraryBase
 {
-	protected OverlayDataAsset[] overlayElementList = new OverlayDataAsset[0];
+	[HideInInspector]
+	public OverlayDataAsset[] overlayElementList = new OverlayDataAsset[0];
 	[NonSerialized]
 	private Dictionary<int, OverlayDataAsset> overlayDictionary;
 

--- a/UMAProject/Assets/UMA/Core/Scripts/SlotLibrary.cs
+++ b/UMAProject/Assets/UMA/Core/Scripts/SlotLibrary.cs
@@ -5,7 +5,8 @@ using System;
 
 public class SlotLibrary : SlotLibraryBase
 {
-	protected SlotDataAsset[] slotElementList = new SlotDataAsset[0];
+	[HideInInspector]
+	public SlotDataAsset[] slotElementList = new SlotDataAsset[0];
 	[NonSerialized]
 	private Dictionary<int, SlotDataAsset> slotDictionary;
 


### PR DESCRIPTION
the overlay and slot librarys need their elementlists set to public to
not cause an error in their respective editors